### PR TITLE
Fix : infinite-scroll in IOS not firing

### DIFF
--- a/src/components/infinite-scroll/infinite-scroll.ts
+++ b/src/components/infinite-scroll/infinite-scroll.ts
@@ -372,9 +372,14 @@ export class InfiniteScroll {
         if (!this._scLsn) {
           this._scLsn = this._content.ionScroll.subscribe(this._onScroll.bind(this));
         }
+        if (!this._escLsn) {
+          this._escLsn = this._content.ionScrollEnd.subscribe(this._onScroll.bind(this));
+        }
       } else {
         this._scLsn && this._scLsn.unsubscribe();
         this._scLsn = null;
+        this._escLsn && this._escLsn.unsubscribe();
+        this._escLsn = null;
       }
     }
   }


### PR DESCRIPTION

#### Short description of what this resolves:
The infinite scroll wouldn't work as expected on IOS devices
when scrolling fast and leaving  the scroll to reach the end by itself 

#### Changes proposed in this pull request:

- Add new event listener in infiniteScroll that listens to scroll end

**Ionic Version**: 2.x / 3.x

**Fixes**: #11994
